### PR TITLE
Implement "Area Chart" components

### DIFF
--- a/src/lib/charts/doughnut-chart.svelte
+++ b/src/lib/charts/doughnut-chart.svelte
@@ -1,9 +1,37 @@
 <script lang="ts">
-  import type { ChartData, ChartOptions, ChartItem } from 'chart.js';
-  import Chart from './chart.svelte';
+  import { onMount, afterUpdate, onDestroy } from 'svelte';
+  import { Chart as ChartJS } from 'chart.js';
+  import type {
+    ChartData,
+    ChartOptions,
+    ChartItem,
+    ChartConfiguration
+  } from 'chart.js';
+
   export let data: ChartData<'doughnut'>,
     options: ChartOptions<'doughnut'>,
     chartID: ChartItem;
+
+  let ref: HTMLCanvasElement;
+  let chart: ChartJS<'doughnut'> | null;
+  const config: ChartConfiguration<'doughnut'> = {
+    type: 'doughnut',
+    data,
+    options
+  };
+  const id = String(chartID);
+  onMount(() => {
+    chart = new ChartJS(ref, config);
+  });
+  afterUpdate(() => {
+    if (!chart) return;
+    chart.data = data;
+    Object.assign(chart.options, options);
+  });
+  onDestroy(() => {
+    if (chart) chart.destroy();
+    chart = null;
+  });
 </script>
 
-<Chart type="doughnut" {data} {options} {chartID} />
+<canvas bind:this={ref} {id} />

--- a/src/lib/charts/doughnut-chart.svelte
+++ b/src/lib/charts/doughnut-chart.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { ChartData, ChartOptions, ChartItem } from 'chart.js';
+  import Chart from './chart.svelte';
+  export let data: ChartData<'doughnut'>,
+    options: ChartOptions<'doughnut'>,
+    chartID: ChartItem;
+</script>
+
+<Chart type="doughnut" {data} {options} {chartID} />

--- a/src/lib/charts/pie-chart.svelte
+++ b/src/lib/charts/pie-chart.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { ChartData, ChartOptions, ChartItem } from 'chart.js';
+  import Chart from './chart.svelte';
+  export let data: ChartData<'pie'>,
+    options: ChartOptions<'pie'>,
+    chartID: ChartItem;
+</script>
+
+<Chart type="pie" {data} {options} {chartID} />

--- a/src/lib/charts/pie-chart.svelte
+++ b/src/lib/charts/pie-chart.svelte
@@ -1,9 +1,37 @@
 <script lang="ts">
-  import type { ChartData, ChartOptions, ChartItem } from 'chart.js';
-  import Chart from './chart.svelte';
+  import { onMount, afterUpdate, onDestroy } from 'svelte';
+  import { Chart as ChartJS } from 'chart.js';
+  import type {
+    ChartData,
+    ChartOptions,
+    ChartItem,
+    ChartConfiguration
+  } from 'chart.js';
+
   export let data: ChartData<'pie'>,
     options: ChartOptions<'pie'>,
     chartID: ChartItem;
+
+  let ref: HTMLCanvasElement;
+  let chart: ChartJS<'pie'> | null;
+  const config: ChartConfiguration<'pie'> = {
+    type: 'pie',
+    data,
+    options
+  };
+  const id = String(chartID);
+  onMount(() => {
+    chart = new ChartJS(ref, config);
+  });
+  afterUpdate(() => {
+    if (!chart) return;
+    chart.data = data;
+    Object.assign(chart.options, options);
+  });
+  onDestroy(() => {
+    if (chart) chart.destroy();
+    chart = null;
+  });
 </script>
 
-<Chart type="pie" {data} {options} {chartID} />
+<canvas bind:this={ref} {id} />

--- a/src/lib/charts/polar-area-chart.svelte
+++ b/src/lib/charts/polar-area-chart.svelte
@@ -1,9 +1,37 @@
 <script lang="ts">
-  import type { ChartData, ChartOptions, ChartItem } from 'chart.js';
-  import Chart from './chart.svelte';
+  import { onMount, afterUpdate, onDestroy } from 'svelte';
+  import { Chart as ChartJS } from 'chart.js';
+  import type {
+    ChartData,
+    ChartOptions,
+    ChartItem,
+    ChartConfiguration
+  } from 'chart.js';
+
   export let data: ChartData<'polarArea'>,
     options: ChartOptions<'polarArea'>,
     chartID: ChartItem;
+
+  let ref: HTMLCanvasElement;
+  let chart: ChartJS<'polarArea'> | null;
+  const config: ChartConfiguration<'polarArea'> = {
+    type: 'polarArea',
+    data,
+    options
+  };
+  const id = String(chartID);
+  onMount(() => {
+    chart = new ChartJS(ref, config);
+  });
+  afterUpdate(() => {
+    if (!chart) return;
+    chart.data = data;
+    Object.assign(chart.options, options);
+  });
+  onDestroy(() => {
+    if (chart) chart.destroy();
+    chart = null;
+  });
 </script>
 
-<Chart type="polarArea" {data} {options} {chartID} />
+<canvas bind:this={ref} {id} />

--- a/src/lib/charts/polar-area-chart.svelte
+++ b/src/lib/charts/polar-area-chart.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { ChartData, ChartOptions, ChartItem } from 'chart.js';
+  import Chart from './chart.svelte';
+  export let data: ChartData<'polarArea'>,
+    options: ChartOptions<'polarArea'>,
+    chartID: ChartItem;
+</script>
+
+<Chart type="polarArea" {data} {options} {chartID} />

--- a/src/lib/charts/radar-chart.svelte
+++ b/src/lib/charts/radar-chart.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { ChartData, ChartOptions, ChartItem } from 'chart.js';
+  import Chart from './chart.svelte';
+  export let data: ChartData<'radar'>,
+    options: ChartOptions<'radar'>,
+    chartID: ChartItem;
+</script>
+
+<Chart type="radar" {data} {options} {chartID} />

--- a/src/routes/doughnut-chart/+page.svelte
+++ b/src/routes/doughnut-chart/+page.svelte
@@ -23,7 +23,7 @@
       datasets: [
         {
           data: [404, 301, 200],
-          label: 'Mmmmm Pie',
+          label: 'Mmmmm Doughnut',
           backgroundColor: ['yellow', 'green', 'red']
         }
       ]

--- a/src/routes/doughnut-chart/+page.svelte
+++ b/src/routes/doughnut-chart/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+    import DoughnutChart from '$lib/charts/doughnut-chart.svelte';
+    import {
+      Chart as ChartJS,
+      PieController,
+      ArcElement,
+      Title,
+      Legend,
+      Filler,
+      type ChartData,
+      type ChartOptions,
+    } from 'chart.js';
+    ChartJS.register(
+      PieController,
+      ArcElement,
+      Filler,
+      Title,
+      Legend
+    );
+
+    const data: ChartData<'doughnut'> = {
+      labels: ['Yellow Slice', 'Green Slice', 'Red Slice'],
+      datasets: [
+        {
+          data: [404, 301, 200],
+          label: 'Mmmmm Pie',
+          backgroundColor: ['yellow', 'green', 'red']
+        }
+      ]
+    };
+
+    const options: ChartOptions<'doughnut'> = {
+      radius: "50%"
+    }
+  </script>
+
+  <DoughnutChart {data} {options} chartID="doughnut-chart-1" />

--- a/src/routes/pie-chart/+page.svelte
+++ b/src/routes/pie-chart/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import PieChart from '$lib/charts/pie-chart.svelte';
+  import {
+    Chart as ChartJS,
+    PieController,
+    ArcElement,
+    Title,
+    Legend,
+    Filler,
+    type ChartData,
+    type ChartOptions,
+  } from 'chart.js';
+  ChartJS.register(
+    PieController,
+    ArcElement,
+    Filler,
+    Title,
+    Legend
+  );
+
+  const data: ChartData<'pie'> = {
+    labels: ['Yellow Slice', 'Green Slice', 'Red Slice'],
+    datasets: [
+      {
+        data: [404, 301, 200],
+        label: 'Mmmmm Pie',
+        backgroundColor: ['yellow', 'green', 'red']
+      }
+    ]
+  };
+
+  const options: ChartOptions<'pie'> = {
+    radius: "50%"
+  }
+</script>
+
+<PieChart {data} {options} chartID="pie-chart-1" />

--- a/src/routes/polar-area-chart/+page.svelte
+++ b/src/routes/polar-area-chart/+page.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import PolarAreaChart from '$lib/charts/polar-area-chart.svelte';
+  import {
+    Chart as ChartJS,
+    PolarAreaController,
+    ArcElement,
+    RadialLinearScale,
+    Title,
+    Legend,
+    Filler,
+    type ChartData,
+    type ChartOptions,
+  } from 'chart.js';
+  ChartJS.register(
+    PolarAreaController,
+    ArcElement,
+    RadialLinearScale,
+    Filler,
+    Title,
+    Legend
+  );
+
+  const data: ChartData<'polarArea'> = {
+    labels: ['Yellow Slice', 'Green Slice', 'Red Slice'],
+    datasets: [
+      {
+        data: [404, 301, 200],
+        label: 'Polar Area Chart Number One',
+        backgroundColor: ['yellow', 'green', 'red']
+      }
+    ]
+  };
+
+  const options: ChartOptions<'polarArea'> = {
+    animation: {
+      animateRotate: false,
+    },
+  }
+
+</script>
+
+<PolarAreaChart {data} {options} chartID="pie-chart-1" />

--- a/src/routes/polar-area-chart/+page.svelte
+++ b/src/routes/polar-area-chart/+page.svelte
@@ -39,4 +39,4 @@
 
 </script>
 
-<PolarAreaChart {data} {options} chartID="pie-chart-1" />
+<PolarAreaChart {data} {options} chartID="polar-area-chart-1" />

--- a/src/routes/radar-chart/+page.svelte
+++ b/src/routes/radar-chart/+page.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import RadarChart from '$lib/charts/radar-chart.svelte';
+  import {
+    Chart as ChartJS,
+    RadarController,
+    LineElement,
+    PointElement,
+    RadialLinearScale,
+    Title,
+    Legend,
+    Filler,
+    type ChartData,
+    type ChartOptions,
+  } from 'chart.js';
+  ChartJS.register(
+    RadarController,
+    LineElement,
+    PointElement,
+    RadialLinearScale,
+    Filler,
+    Title,
+    Legend
+  );
+
+  const data: ChartData<'radar'> = {
+    labels: ['Increasing Y', 'Increasing X', 'Decreasing X'],
+    datasets: [
+      {
+        data: [404, 301, 200],
+        label: 'Scanning For Data...',
+        backgroundColor: 'yellow'
+      },
+      {
+        data: [301, 200, 404],
+        label: 'Scanning For Data...',
+        backgroundColor: 'green'
+      },
+      {
+        data: [200, 404, 301],
+        label: 'Scanning For Data...',
+        backgroundColor: 'red'
+      }
+    ]
+  };
+
+  const options: ChartOptions<'radar'> = {};
+
+</script>
+
+<RadarChart {data} {options} chartID="radar-chart-1" />

--- a/src/routes/radar-chart/+page.svelte
+++ b/src/routes/radar-chart/+page.svelte
@@ -27,17 +27,17 @@
     datasets: [
       {
         data: [404, 301, 200],
-        label: 'Scanning For Data...',
+        label: 'Scanning For Dataset 1...',
         backgroundColor: 'yellow'
       },
       {
         data: [301, 200, 404],
-        label: 'Scanning For Data...',
+        label: 'Scanning For Dataset 2...',
         backgroundColor: 'green'
       },
       {
         data: [200, 404, 301],
-        label: 'Scanning For Data...',
+        label: 'Scanning For Dataset 3...',
         backgroundColor: 'red'
       }
     ]


### PR DESCRIPTION
![Screenshot 2023-03-22 200515](https://user-images.githubusercontent.com/46794001/227072650-f9b2f3d7-ec74-489c-a26b-44ec544ef6ff.png)
![Screenshot 2023-03-22 200534](https://user-images.githubusercontent.com/46794001/227072652-c7f9d053-202c-4912-b43b-2c587754f86f.png)
![Screenshot 2023-03-22 200549](https://user-images.githubusercontent.com/46794001/227072653-bdd40569-ccce-48a4-b240-68b7ce0d2a0c.png)
![Screenshot 2023-03-22 200558](https://user-images.githubusercontent.com/46794001/227072655-015aa1c4-e4e9-4840-a567-80b9a6dc5f00.png)

Rather than highlighting individual commits (since I actively made revisions while working on this PR) going to higher level overview the additions.

I split off the "Area Charts" to pull what would be the "Chart" root component definition up a level to their respective implementation component instead. This is due to the  `ChartOptions ` type for each one not only conflicting with each other but the core ChartJs  ` ChartOptions` type as well.

Essentially all these charts data shapes are the same (pie and doughnut being identical other than their  ` options.type`  value) so their actual implementations aren't that complex. The plan from here is to implement both  `Scatter` and  `Mixed` chart types and clean up the example implementations to move the "tree shakeable" stuff back into the respective component.

This makes it so each component is isolated and the only things that should need to be "setup" to use a component is the data to be loaded (in the correct format for the chart) and any additional chart options alongside the respective  `chartID` (basically the only thing that needs to be done to use the component is register ChartJS plugins/chart options and pass in the respective props to the component) .